### PR TITLE
fix typo

### DIFF
--- a/Frontend/src/assets/Properties/blockchain-bar/text.md
+++ b/Frontend/src/assets/Properties/blockchain-bar/text.md
@@ -2,7 +2,7 @@ The *Bar* is very exlusive to *member-only*, registering to become one is very e
 &nbsp;  
 ## Access Control Vulnerabilities
 
-Access control vulnerability allow unathorized users to access or modify data or functions through security flaws, the flaw some times doesn't need to be extremely hard to find or something, sometime it's just a tiny little mistake made by the devs just like in web2 with loose comparison. In Solidity Smart Contract, the Access Control Vulnerability means that unauthorized user may modify or access the contract's data or functions. &nbsp;  
+Access control vulnerability allow unathorized users to access or modify data or functions through security flaws, the flaw sometimes doesn't need to be extremely hard to find or something, sometime it's just a tiny little mistake made by the devs just like in web2 with loose comparison. In Solidity Smart Contract, the Access Control Vulnerability means that unauthorized user may modify or access the contract's data or functions. &nbsp;  
 &nbsp;  
 
 Most of the time, the access control vulnerability is just the beginning of the real disaster, as it acts as the entry point to any other vulnerability such as Denial of Service, Reentrancy, etc. &nbsp;  

--- a/Frontend/src/assets/Properties/blockchain-briefing/text.md
+++ b/Frontend/src/assets/Properties/blockchain-briefing/text.md
@@ -61,7 +61,7 @@ In this introduction, we will try to work with the most basic Foundry Cast comma
     cast call -r $RPC_URL $SetupADDR "brief()"
     ```
     &nbsp;  
-    You will get a return of 32 bytes, 20 bytes is the real address while the rest is just a padding to fulfill the 32 btyes standard of a SLOT, we will talk about this later in this same challenge.&nbsp; 
+    You will get a return of 32 bytes, 20 bytes is the real address while the rest is just a padding to fulfill the 32 bytes standard of a SLOT, we will talk about this later in this same challenge.&nbsp; 
     Now that we have the address of *Briefing Contract*, we can then interact with anything inside it, like its Functions and Variables, let's try calling a variable and see its value, let's call *completedCall*, &nbsp;  
     &nbsp; 
     ```text
@@ -144,12 +144,12 @@ SLOT 3| number_three (32 bytes)
 Right now, you maybe have these questions &nbsp;  
 &nbsp;  
 - Why can't *number_three* be stored 3 bytes on the SLOT 2 and the remaining bytes on SLOT 3?&nbsp; 
-&nbsp; 
+    &nbsp; 
     The rules of the solidity storage system, prevent this type of storage, a storage that is reserved or required for a certain type of variable is absolute and cannot be divided.&nbsp;  
     &nbsp;  
 
 - Why the address public immutable player is not stored on the Storage?&nbsp; 
-&nbsp; 
+    &nbsp; 
     Both constant and immutable; a variable that is always has the same value and cannot be changed, are stored in the contract bytecode instead of the EVM Storage.&nbsp;  
     &nbsp;  
 

--- a/Frontend/src/assets/Properties/blockchain-entry-point/text.md
+++ b/Frontend/src/assets/Properties/blockchain-entry-point/text.md
@@ -1,4 +1,4 @@
-At the grand gates of the casino, known as the *Entry Point*, only those who managed to get the exact amount of deposit can cross into the high-stakes games. Manye eager players approach with pockets jingling, exchanging their precious ether for tokens at the shimmering kisok. Despite their careful calculations, some finds themselves just shy of the threshold-denied entry by the Gatekeeper. It's rumored that they deals in absolutes, not even the smallest miscalculation leaves hopeful standing on the outside. &nbsp;  
+At the grand gates of the casino, known as the *Entry Point*, only those who managed to get the exact amount of deposit can cross into the high-stakes games. Many eager players approach with pockets jingling, exchanging their precious ether for tokens at the shimmering kiosk. Despite their careful calculations, some finds themselves just shy of the threshold-denied entry by the Gatekeeper. It's rumored that they deals in absolutes, not even the smallest miscalculation leaves hopeful standing on the outside. &nbsp;  
 &nbsp;  
 
 ## Rounding Error

--- a/Frontend/src/assets/Properties/blockchain-gearing-up/text.md
+++ b/Frontend/src/assets/Properties/blockchain-gearing-up/text.md
@@ -55,7 +55,7 @@ contract Exploit{
 }
 ```
 &nbsp;  
-After we import the contracts, we can now make a variable that will reference to a contract instance, for this we need to know the *Contract Name*, this name is defined after the keyword *contract*. To refet to both *Setup* and *GearingUp* with their respective deployed address we can do this &nbsp;  
+After we import the contracts, we can now make a variable that will reference to a contract instance, for this we need to know the *Contract Name*, this name is defined after the keyword *contract*. To refer to both *Setup* and *GearingUp* with their respective deployed address we can do this &nbsp;  
 &nbsp;  
 
 ```solidity

--- a/Frontend/src/assets/Properties/blockchain-master-of-blackjack/text.md
+++ b/Frontend/src/assets/Properties/blockchain-master-of-blackjack/text.md
@@ -1,4 +1,4 @@
-*Beginner's Luck* is a curious phenomenon often whispered about in the lively halls of casinos, where first-times seem to defy the odds and walk away with unxepected wins. Whether it's hitting a blackjack, landing a lucky number on the roulette wheel, or scoring a jackpot on the slots, these early victories cam feel almost magical, right? But you are not one of them, luck is not a factor in your journey, you have no luck, you just, PRECISE! &nbsp;  
+*Beginner's Luck* is a curious phenomenon often whispered about in the lively halls of casinos, where first-times seem to defy the odds and walk away with unexpected wins. Whether it's hitting a blackjack, landing a lucky number on the roulette wheel, or scoring a jackpot on the slots, these early victories cam feel almost magical, right? But you are not one of them, luck is not a factor in your journey, you have no luck, you just, PRECISE! &nbsp;  
 &nbsp;  
 
 ## Timestamp Dependence

--- a/Frontend/src/assets/Properties/blockchain-silent-dealer/text.md
+++ b/Frontend/src/assets/Properties/blockchain-silent-dealer/text.md
@@ -63,4 +63,4 @@ Notice that the *bytes32* return is a hash, we only take the first 4 bytes, and 
     selector                        Argument (address)
 ```
 &nbsp;  
-so essentially, it first use the 4 bytes signature folloed by the argument in a 32-bytes (slot) format, well if the function require more argument, it could be longer but it will be always the multiples of 32 / slot.
+so essentially, it first use the 4 bytes signature followed by the argument in a 32-bytes (slot) format, well if the function require more argument, it could be longer but it will be always the multiples of 32 / slot.

--- a/Frontend/src/assets/Properties/blockchain-singular-entity/text.md
+++ b/Frontend/src/assets/Properties/blockchain-singular-entity/text.md
@@ -6,7 +6,7 @@ A Hash Collision occurs when two different input produce the same hash value usi
 &nbsp;  
 
 ## What's the Causes?
-In solidity, the root of the problem is often *abi.encodePacked()* function that normally then be hashed using *keccak256()*. When *abi.encodePacked()* is used with multiple variable-length arguments (such as strings and array), the packed encoding does not include information about the boundaries betweeen different arguments abd just combine them, this can lead to situations where different combinations of arguments result in the same encoded output, causing hash collisions, take this for example &nbsp;  
+In solidity, the root of the problem is often *abi.encodePacked()* function that normally then be hashed using *keccak256()*. When *abi.encodePacked()* is used with multiple variable-length arguments (such as strings and array), the packed encoding does not include information about the boundaries betweeen different arguments and just combine them, this can lead to situations where different combinations of arguments result in the same encoded output, causing hash collisions, take this for example &nbsp;  
 &nbsp;  
 
 ```solidity

--- a/Frontend/src/assets/Properties/blockchain-unlimited-credit-line/text.md
+++ b/Frontend/src/assets/Properties/blockchain-unlimited-credit-line/text.md
@@ -14,7 +14,7 @@ The ERC-20 Standard is widely used for a variety of purposes, including: &nbsp;
     Many project issue ERC-20 tokens to represent cryptocurrencies, allowing easy transfers and payment within the Ethereum network. &nbsp;  
     &nbsp;  
 - **Utility Tokens**
-    Some dApps use ERc-20 tokens to grant access to specific services or products within their platforms (e.g., Chainlink's *LINK* token) &nbsp;  
+    Some dApps use ERC-20 tokens to grant access to specific services or products within their platforms (e.g., Chainlink's *LINK* token) &nbsp;  
     &nbsp;  
 - **Stablecoins**
     ERC-20 tokens are often used to represent **stablecoins** pegged to fiat currencies (e.g., USDT, USDC), enabling low-volatility transaction on the blockchain. &nbsp;  

--- a/Frontend/src/assets/Properties/blockchain-voting-frenzy/text.md
+++ b/Frontend/src/assets/Properties/blockchain-voting-frenzy/text.md
@@ -3,7 +3,7 @@ In the heart of the Casino lies the ultimate test of influence, ENUMA and ALPHA 
 
 ## Logic Errors
 
-Logic error in smart contracts refers to a flaw or unintended behavior in the design or implementation of the contract's logic, unlike bugs like overflow or reentrancy attacks, logic errors occur when the contract **doesn't perform the expectede task correctly**, even though the code is syntactically correct. This can lead to unexpected outcomes, like financial loss, or security vulnerabilities. Some of the example may include but not limited to: &nbsp;  
+Logic error in smart contracts refers to a flaw or unintended behavior in the design or implementation of the contract's logic, unlike bugs like overflow or reentrancy attacks, logic errors occur when the contract **doesn't perform the expected task correctly**, even though the code is syntactically correct. This can lead to unexpected outcomes, like financial loss, or security vulnerabilities. Some of the example may include but not limited to: &nbsp;  
 &nbsp;  
 
 1. **Voting System Logic Flaw** &nbsp;  

--- a/Frontend/src/pages/Documentation.jsx
+++ b/Frontend/src/pages/Documentation.jsx
@@ -127,7 +127,7 @@ const DocumentLayout = () => {
                     <li><a href="https://app.hats.finance/audit-competitions">Hats finance</a></li>
                 </ul>
                 <br />
-                <p>Goot to Read</p>
+                <p>Good to Read</p>
                 <ul>
                     <li><a href="https://www.rareskills.io/">Rareskills</a></li>
                 </ul>


### PR DESCRIPTION
documentation -> good to read V
briefing text.md -> fulfill the 32 bytes V
gearing up text.md -> to refer both Setup and GearingUp with their respective deployed address we can do this   V
entry point text.md -> Many eager players approach with pockets jingling, tokens at the shimmering kiosk V
blockchain bar text.md -> sometimes V
master of blackjack text.md-> unexpected V
voting frenzy text.md -> expected V
Silent Dealer text.md -> followed V
singular entity text.md -> Different arguments and just combine them V
unlimited credit line text.md -> ERC